### PR TITLE
Improve multipart parser performance (from quadratic to linear)

### DIFF
--- a/Sources/Multipart/Parser.swift
+++ b/Sources/Multipart/Parser.swift
@@ -137,7 +137,7 @@ public final class Parser {
         
         hasFinished = true
         
-        let raw = Array(buffer[cursor...])
+        let raw = Array(buffer[cursor..<buffer.endIndex])
         let body = Array(raw.trimmed([.newLine, .carriageReturn]))
 
         buffer = []

--- a/Sources/Multipart/Parser.swift
+++ b/Sources/Multipart/Parser.swift
@@ -23,7 +23,7 @@ public final class Parser {
     /// A callback type for handling the parsed epilogue.
     public typealias EpilogueCallback = (Bytes) -> ()
     
-    /// CAlled once after the epilogue has been parsed.
+    /// Called once after the epilogue has been parsed.
     public var onEpilogue: EpilogueCallback?
     
     /// Possible errors that may be encountered while parsing.
@@ -102,7 +102,7 @@ public final class Parser {
     
     // A buffer for the bytes that have been parsed.
     // This allows for a reduction in the number of copies
-    // needed for each step as only indecies into this array
+    // needed for each step as only indices into this array
     // need to be passed around.
     private var buffer: Bytes
     

--- a/Tests/MultipartTests/ParserTests.swift
+++ b/Tests/MultipartTests/ParserTests.swift
@@ -130,7 +130,7 @@ class ParserTests: XCTestCase {
     func testEpilogue() throws {
         let parser = try Parser(boundary: "foo")
         
-        let epilogue = "epliogue"
+        let epilogue = "epilogue"
         
         var message = ""
         message += "preamble"

--- a/Tests/MultipartTests/ParserTests.swift
+++ b/Tests/MultipartTests/ParserTests.swift
@@ -12,6 +12,8 @@ class ParserTests: XCTestCase {
         ("testHeaders", testHeaders),
         ("testEpilogue", testEpilogue),
         ("testFormData", testFormData),
+        ("testExtractBoundary", testExtractBoundary),
+        ("testExtractBoundaryWithQuotes", testExtractBoundaryWithQuotes),
     ]
 
     func testInit() throws {


### PR DESCRIPTION
This PR dramatically improves the performance of the multipart parser for large inputs.

Here's a comparison using the performance test that's part of this PR:

### Before

Time to parse a multipart message with the given size. Measured on a 4-core 2.6 GHz Intel Core i7, macOS 10.13.3, Swift 4.0.3:

Message Size | Debug Build | Release Build
-------------|-------------|--------------
100 KB       | 0.36 s	      | 0.16 s
200 KB       | 1.24 s	      | 0.58 s
400 KB       | 4.56 s      | 2.21 s

### After

Message Size | Debug Build   |Speedup| Release Build | Speedup
-------------|---------|------|------------|---
100 KB       | 0.09 s	 | 4×   | 0.027 s | 6×
200 KB       | 0.19 s	 | 6.5× | 0.06 s  | 10×
400 KB       | 0.37 s       | 12× |  0.11 s  | 20×

It's pretty clear from the numbers that the current parser's performance characteristic is quadratic (O(n²)), whereas my changed code is linear (O(n)). The reason for the previous quadratic behavior is that the parser creates a fresh array (effectively copying all remaining bytes in the buffer) on each run through the parse loop.

My solution works with `ArraySlice`s internally and only creates copies before passing completed parts to the callbacks.

### No API Change

The public API of the `Parser` class hasn't changed.

### Caveats

* I wrote the performance test using XCTest's [`measure`](https://developer.apple.com/documentation/xctest/xctestcase/1496277-measuremetrics) API. I don't know if you can integrate this into your CI workflow or if you have a different setup for performance tests (frankly, I haven't checked).
* I haven't tested it on Linux. I don't doubt that the relative speedup will be similar on Linux, but I have no idea if the XCTest performance tests even work on Linux or how easy they are to integrate with your CI workflow.

### Future Improvements

I tried hard to make a minimal amount of changes, but there are some more things that I think could be improved (they'd have a much smaller performance impact though):

1. Make similar changes to `HeaderParser` and `BoundaryParser`. I haven't looked at those types, but I assume they also make too many copies. The impact of these components on overall performance is likely small, though.

2. Provide a version of `Array.trimmed` (in Core) for `ArraySlice` (or provide a generic version for `BidirectionalCollection`). This would save us one copy per parsed part and also be more elegant.

3. Ideally from a performance perspective, the callbacks `onPreamble`, `onPart` and `onEpilogue` would pass `ArraySlice`s instead of arrays to the caller. This would save us one copy per parsed part, and IMHO it would also fit the API very nicely. Parsing is similar to methods like `Sequence.split` (which returns an array of subsequences), so callers should be used to getting _slices_ of the original data back. The type of the parameter in the callback function would be a good signal to the caller that they should make a copy of this value if they want to store it permanently.

   This would be a source-/API-breaking change, though. Let me know if you'd consider a change like this for Vapor 3.

4. Speaking of API changes, make the `parse(bytes:)` method accept any sequence or collection of bytes. This doesn't have any performance impact, but I'd think it would be a nice improvement if the method accepted other input types. This would technically be an API change, though probably not source breaking for clients.

5. Lastly, move the loop from `parse(bytes:)` into the actual parse function. In the current setup, we loop over the bytes in `parse(bytes:)` and then call the actual parse function from the loop. IMHO it would be more elegant to move the loop into the private parse function. This may also be a little faster, but probably not much.